### PR TITLE
Update custom-node-list.json

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -31191,6 +31191,16 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "millerlight",
+            "title": "Key-Value KV-Tools for ComfyUI",
+            "reference": "https://github.com/millerlight/ComfyUI-KVTools",
+            "files": [
+                "https://github.com/millerlight/ComfyUI-KVTools"
+            ],
+            "install_type": "git-clone",
+            "description": "Nodes for JSON Key/Value (KV) storage with on-the-fly UI preview, dynamic drop-downs, random selection, and inline edit mode."
         }
     ]
 }


### PR DESCRIPTION
Thanks for the earlier security feedback.
In v1.0.0 I now strictly enforce a registry-backed whitelist:

    POST /kvtools/peek only serves values for (file_name, key) that exist in kv_registry.json (basename-only, path traversal blocked via abspath().startswith(BASE_DIR)).

    Image serving is scoped to the allowed root (optional extension whitelist), no arbitrary paths.

    UI changes no longer trigger automatic runs.